### PR TITLE
Remove extraneous comma from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ const IMAGE_HEIGHT = 80
 const PostFragment = graphql`
   post {
     title,
-    published_at,
+    published_at
   }
 `
 const UserQuery = graphql`


### PR DESCRIPTION
This currently fails with a syntax error.
